### PR TITLE
Ruake.tscn -> ruake.tscn

### DIFF
--- a/addons/ruake/ruake/ruake_layer.gd
+++ b/addons/ruake/ruake/ruake_layer.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
 
 var ruake: Ruake
-const RuakeScene = preload("./Ruake.tscn")
+const RuakeScene = preload("./ruake.tscn")
 var action_name
 
 signal ruake_opened


### PR DESCRIPTION
Most linux filesystems (and some mac filesystems) are case sensitive. So its important that the `preload` call matches the case.